### PR TITLE
Vanilla Ruby supports ActiveEmoji

### DIFF
--- a/lib/active_emoji.rb
+++ b/lib/active_emoji.rb
@@ -1,3 +1,2 @@
-Dir[File.dirname(__FILE__) + '/active_emoji/core_ext/*.rb'].each do |file|
-  require file
-end
+require_relative 'support/load_helper.rb'
+load_all_loadable_classes

--- a/lib/active_emoji/core_ext/array.rb
+++ b/lib/active_emoji/core_ext/array.rb
@@ -5,6 +5,7 @@ class Array
   alias 🔁 each
   alias 🈳❓ empty?
   alias 🍀 sample
+  alias 🎲 sample
   alias ♻️ shuffle
   alias 👈 push
   alias 🍕 slice

--- a/lib/active_emoji/core_ext/enumerable.rb
+++ b/lib/active_emoji/core_ext/enumerable.rb
@@ -6,6 +6,8 @@ module Enumerable
   alias 🔁🍕 each_slice
   alias 🔎 find
   alias 💉 inject
+  alias 🦁🐱🐭 reduce
+  alias 🐘🐀🐁 reduce
   alias 😴 lazy
   alias 📍 map
   alias 🈚️❓ none?

--- a/lib/active_emoji/core_ext/file.rb
+++ b/lib/active_emoji/core_ext/file.rb
@@ -2,6 +2,6 @@ class File
   class << self
     alias 📁❓ directory?
     alias 🌍📖❓ world_readable?
-    alias 🌍✍❓ world_writeable?
+    alias 🌍✍❓ world_writable?
   end
 end

--- a/lib/active_emoji/core_ext/object.rb
+++ b/lib/active_emoji/core_ext/object.rb
@@ -1,5 +1,6 @@
 class Object
   alias ⛄️❓ frozen?
+  alias ❄️❓ frozen?
   alias ❄️ freeze
   alias :"#️⃣" hash
   alias 🔬 inspect

--- a/lib/active_emoji/core_ext/object.rb
+++ b/lib/active_emoji/core_ext/object.rb
@@ -1,6 +1,7 @@
 class Object
   alias ⛄️❓ frozen?
   alias ❄️❓ frozen?
+  alias ⛄️ freeze
   alias ❄️ freeze
   alias :"#️⃣" hash
   alias 🔬 inspect

--- a/lib/support/load_helper.rb
+++ b/lib/support/load_helper.rb
@@ -1,0 +1,35 @@
+# Helper to facilitate errorlessly loading the classes aliased by ActiveEmoji
+
+# List of files for all ActiveEmoji aliased classes
+FILELIST = Dir[File.dirname(__FILE__) + '/active_emoji/core_ext/*.rb']
+
+def load_all_loadable_classes
+  # Load aliases for all classes that exist in memory at runtime
+  if rails_loaded?
+    load_all_classes
+  else
+    load_all_classes_except 'date.rb'
+  end
+end
+
+
+
+# Constituent methods of load_all_loadable_classes
+
+def rails_loaded?
+  # TODO: Extend to accept top-level constants for any library as argument
+  defined?(Rails) ? true : false
+end
+
+def load_all_classes
+  FILELIST.each do |file|
+    require file
+  end
+end
+
+def load_all_classes_except(unwanted_class)
+  # TODO: Extend this method to accept an array
+  FILELIST.each do |file|
+    require file unless file.include? unwanted_class
+  end
+end


### PR DESCRIPTION
Adds some extensible logic to prevent ActiveEmoji from erroring out when required in a project that doesn't include a 'Date' object. 

This PR also contains the reduce and sample aliases from the Additions PR, as well as the Additions changes of fixing the world_writeable bug and extending the freeze and frozen aliases on Object. The purpose there is so that there is naming consistency between freezing an object and checking if it is frozen. 

Forgot to checkout back to master before starting work on this one :P